### PR TITLE
Fix #reset clearing client data

### DIFF
--- a/P3.package/P3Client.class/instance/clearSSL.st
+++ b/P3.package/P3Client.class/instance/clearSSL.st
@@ -1,3 +1,3 @@
 private
 clearSSL
-	properties removeKey: 'ssl' ifAbsent: [ ]
+	settings removeKey: #ssl ifAbsent: [ ]

--- a/P3.package/P3Client.class/instance/close.st
+++ b/P3.package/P3Client.class/instance/close.st
@@ -7,5 +7,5 @@ close
 			[ 
 				self writeMessage: #[] tag: $X. 
 				connection close ] on: Error do: [  ].
-			properties at: 'connected' put: 'false'.
+			settings at: #connected put: false.
 			connection := nil ]

--- a/P3.package/P3Client.class/instance/database..st
+++ b/P3.package/P3Client.class/instance/database..st
@@ -3,4 +3,4 @@ database: string
 	"Set the name of the database to connect to.
 	Set to nil or do not set to use the default."
 	
-	properties at: #database put: string
+	settings at: #database put: string

--- a/P3.package/P3Client.class/instance/database.st
+++ b/P3.package/P3Client.class/instance/database.st
@@ -3,4 +3,4 @@ database
 	"Return the database name I (want to) connect to.
 	For the default, nil is used."
 	
-	^ properties at: #database ifAbsent: [ nil ]
+	^ settings at: #database ifAbsent: [ nil ]

--- a/P3.package/P3Client.class/instance/host..st
+++ b/P3.package/P3Client.class/instance/host..st
@@ -3,4 +3,4 @@ host: string
 	"Set the name of the host to connect to.
 	If not set, defaults to localhost."
 	
-	properties at: #host put: string
+	settings at: #host put: string

--- a/P3.package/P3Client.class/instance/host.st
+++ b/P3.package/P3Client.class/instance/host.st
@@ -3,4 +3,4 @@ host
 	"Return the host name I (want to) connect to.
 	The default is localhost."
 
-	^ properties at: #host ifAbsentPut: [ 'localhost' ]
+	^ settings at: #host ifAbsentPut: [ 'localhost' ]

--- a/P3.package/P3Client.class/instance/initialize.st
+++ b/P3.package/P3Client.class/instance/initialize.st
@@ -1,4 +1,6 @@
 initialize-release
 initialize
 	super initialize.
-	properties := Dictionary new
+	
+	settings := IdentityDictionary new.
+	properties := Dictionary new.

--- a/P3.package/P3Client.class/instance/isConnected.st
+++ b/P3.package/P3Client.class/instance/isConnected.st
@@ -4,4 +4,4 @@ isConnected
 
 	^ connection notNil 
 		and: [ connection isConnected 
-			and: [ (properties at: 'connected' ifAbsent: [ 'false' ]) = 'true' ] ]
+			and: [ (settings at: #connected ifAbsent: [ false ]) ] ]

--- a/P3.package/P3Client.class/instance/isSSL.st
+++ b/P3.package/P3Client.class/instance/isSSL.st
@@ -2,4 +2,4 @@ testing
 isSSL
 	"Return true if my current connection is SSL encrypted"
 	
-	^ (properties at: 'ssl' ifAbsent: [ 'false' ]) = 'true'
+	^ settings at: #ssl ifAbsent: [ false ]

--- a/P3.package/P3Client.class/instance/password..st
+++ b/P3.package/P3Client.class/instance/password..st
@@ -3,4 +3,4 @@ password: string
 	"Set the password to use when connecting.
 	Set to nil or don't set to use no password."
 
-	properties at: #password put: string
+	settings at: #password put: string

--- a/P3.package/P3Client.class/instance/password.st
+++ b/P3.package/P3Client.class/instance/password.st
@@ -3,4 +3,4 @@ password
 	"Return the password  of my database connection.
 	For no password, nil is used."
 
-	^ properties at: #password ifAbsent: [ nil ]
+	^ settings at: #password ifAbsent: [ nil ]

--- a/P3.package/P3Client.class/instance/port..st
+++ b/P3.package/P3Client.class/instance/port..st
@@ -3,4 +3,4 @@ port: integer
 	"Set the port to connect to.
 	If not set, defaults to 5432."
 	
-	properties at: #port put: integer
+	settings at: #port put: integer

--- a/P3.package/P3Client.class/instance/port.st
+++ b/P3.package/P3Client.class/instance/port.st
@@ -3,4 +3,4 @@ port
 	"Return the port I (want to) connect to.
 	The default is 5432."
 
-	^ properties at: #port ifAbsentPut: [ 5432 ]
+	^ settings at: #port ifAbsentPut: [ 5432 ]

--- a/P3.package/P3Client.class/instance/processParameterStatus..st
+++ b/P3.package/P3Client.class/instance/processParameterStatus..st
@@ -2,6 +2,9 @@ private
 processParameterStatus: payload
 	"Do not yet use the converter since it is not yet initialized"
 	
-	properties 
-		at: (self converter asciiCStringFrom: payload)
-		put: (self converter asciiCStringFrom: payload)
+	| key value |
+	
+	key := self converter asciiCStringFrom: payload.
+	value := self converter asciiCStringFrom: payload.
+		
+	properties at: key put: value

--- a/P3.package/P3Client.class/instance/query..st
+++ b/P3.package/P3Client.class/instance/query..st
@@ -5,6 +5,7 @@ query: query
 	Descriptions is a collection of row field description objects.
 	Data is a collection of rows with fully converted field values as objects."
 
-	self ensureConnected.
-	self	writeQueryMessage: query.
-	^ self runQueryResult
+	^ self 
+		ensureConnected;
+		writeQueryMessage: query;
+		runQueryResult

--- a/P3.package/P3Client.class/instance/reset.st
+++ b/P3.package/P3Client.class/instance/reset.st
@@ -1,4 +1,5 @@
 private
 reset
 	properties removeAll.
+	settings at: #connected put: false.
 	converter := nil

--- a/P3.package/P3Client.class/instance/setConnected.st
+++ b/P3.package/P3Client.class/instance/setConnected.st
@@ -1,3 +1,4 @@
 private
 setConnected
-	properties at: 'connected' put: 'true'
+
+	settings at: #connected put: true

--- a/P3.package/P3Client.class/instance/setSSL.st
+++ b/P3.package/P3Client.class/instance/setSSL.st
@@ -1,3 +1,3 @@
 private
 setSSL
-	properties at: 'ssl' put: 'true'
+	settings at: #ssl put: true

--- a/P3.package/P3Client.class/instance/timeout..st
+++ b/P3.package/P3Client.class/instance/timeout..st
@@ -1,3 +1,4 @@
 initialize-release
 timeout: seconds
-	^ properties at: #timeout put: seconds
+
+	settings at: #timeout put: seconds

--- a/P3.package/P3Client.class/instance/timeout.st
+++ b/P3.package/P3Client.class/instance/timeout.st
@@ -2,4 +2,4 @@ accessing
 timeout
 	"Return the timeout in seconds I (want to) use, the default being 10 seconds."
 	
-	^ properties at: #timeout ifAbsentPut: [ 10 ]
+	^ settings at: #timeout ifAbsentPut: [ 10 ]

--- a/P3.package/P3Client.class/instance/user..st
+++ b/P3.package/P3Client.class/instance/user..st
@@ -3,4 +3,4 @@ user: string
 	"Set the user to use when connecting.
 	Set to nil or don't set to use the default."
 	
-	properties at: #user put: string
+	settings at: #user put: string

--- a/P3.package/P3Client.class/instance/user.st
+++ b/P3.package/P3Client.class/instance/user.st
@@ -3,4 +3,4 @@ user
 	"Return the user of my database connection.
 	For the default, nil is used."
 
-	^ properties at: #user ifAbsent: [ nil ]
+	^ settings at: #user ifAbsent: [ nil ]

--- a/P3.package/P3Client.class/properties.json
+++ b/P3.package/P3Client.class/properties.json
@@ -7,6 +7,7 @@
 	"classvars" : [ ],
 	"instvars" : [
 		"connection",
+		"settings",
 		"properties",
 		"converter",
 		"message"

--- a/P3.package/P3ClientTests.class/instance/supportsJsonB.st
+++ b/P3.package/P3ClientTests.class/instance/supportsJsonB.st
@@ -1,0 +1,11 @@
+versionInfo
+supportsJsonB
+
+	| record version |
+	
+	record := (client query: 'SHOW server_version') firstRecord.
+	version := ($. split: record first) collect: [ :part | part asNumber ].
+	
+	^ version first > 9 or: [ 
+		version first = 9 and: [ version second > 4 ]		
+	]

--- a/P3.package/P3ClientTests.class/instance/testJsonConversion.st
+++ b/P3.package/P3ClientTests.class/instance/testJsonConversion.st
@@ -1,6 +1,8 @@
 testing
 testJsonConversion
 	| data result |
+	
+	self supportsJsonB ifFalse: [ ^ self skip ].
 	data := NeoJSONObject new 
 		x: 1; 
 		str: 'les élève Français'; 

--- a/P3.package/P3Converter.class/instance/printOn..st
+++ b/P3.package/P3Converter.class/instance/printOn..st
@@ -4,5 +4,5 @@ printOn: stream
 	stream nextPut: $(.
 	stream print: self encoder identifier.
 	stream space.
-	stream print: self timezone id.
+	self timezone ifNotNil: [ :tmz | stream print: tmz id ].
 	stream nextPut: $)


### PR DESCRIPTION
Fix connection resetting client information causing it to loose username and password.
Split state information and client information into two dictionaries.

Only run jsonB test if the version supports it.