### PR TITLE
P3PreparedStatement: improve bind parameters conversion

### DIFF
--- a/P3-Tests/P3ClientTest.class.st
+++ b/P3-Tests/P3ClientTest.class.st
@@ -157,6 +157,28 @@ P3ClientTest >> testBooleanConversion [
 ]
 
 { #category : #testing }
+P3ClientTest >> testByteArrayConversion [
+
+	| result bytes |
+	
+	client execute: 'DROP TABLE IF EXISTS testBytea'.
+	client execute: 'CREATE TABLE testBytea (id int, bytes bytea)'.
+	
+	bytes := #[ 0 1 2 3 4 254 255 ].	
+	client execute: ('INSERT INTO testBytea (id, bytes) VALUES (100, ''{1}'')' format: { '\x', bytes hex }).
+
+	"Read the bytes back as a hex string"
+	result := client query: 'SELECT encode(bytes, ''hex'') FROM testBytea WHERE id = 100'.
+	self assert: result firstRecord first asLowercase equals: bytes hex asLowercase.
+
+	"Read the bytes back as binary data"	
+	result := client query: 'SELECT bytes FROM testBytea WHERE id = 100'.
+	self assert: result firstRecord first equals: bytes.
+
+	client execute: 'DROP TABLE testBytea'
+]
+
+{ #category : #testing }
 P3ClientTest >> testChronology [
 	| result |
 	client execute: 'DROP TABLE IF EXISTS table1'.

--- a/P3-Tests/P3PreparedStatementTest.class.st
+++ b/P3-Tests/P3PreparedStatementTest.class.st
@@ -148,6 +148,33 @@ P3PreparedStatementTest >> testMultipleInsertStatements [
 ]
 
 { #category : #tests }
+P3PreparedStatementTest >> testScaledDecimal [
+
+	| statement result |
+	
+	client execute: 'DROP TABLE IF EXISTS table1'.
+	client execute: 'CREATE TABLE table1 (id INTEGER, nr NUMERIC(10,2))'.
+	
+	statement := client prepare: 'INSERT INTO table1 (id, nr) VALUES ($1,$2)'.
+	statement execute: #( 10 100 ).
+	statement execute: #( 20 100.12 ).
+	statement execute: #( 30 100.12s2 ).
+	statement execute: #( 40 100.123s2 ).
+	statement execute: #( 50 100.129s2 ).
+	statement close.
+	
+	statement := client prepare: 'SELECT nr FROM table1 ORDER BY id'.
+	result := statement query: #( ).
+	statement close.
+	
+	self assert: (result data collect: [ :row | row first asScaledDecimal ]) asArray
+		equals: #( 100 100.12s2 100.12s2 100.12s2 100.13s2 ).
+	
+
+
+]
+
+{ #category : #tests }
 P3PreparedStatementTest >> testSelectStatement [
 
 	| statement result |

--- a/P3-Tests/P3PreparedStatementTest.class.st
+++ b/P3-Tests/P3PreparedStatementTest.class.st
@@ -55,6 +55,28 @@ P3PreparedStatementTest >> testBatchInsertStatement [
 ]
 
 { #category : #tests }
+P3PreparedStatementTest >> testBinaryColumn [
+
+	| statement result |
+	
+	client execute: 'DROP TABLE IF EXISTS table1'.
+	client execute: 'CREATE TABLE table1 (id INTEGER, bytes BYTEA)'.
+	
+	statement := client prepare: 'INSERT INTO table1 (id, bytes) VALUES ($1,$2)'.
+	statement execute: #( 123 #[ 100 102 104 106 108 ] ).
+	statement execute: #( 345 #[ 100 102 104 106 108 100 102 104 106 108 ]  ).
+	statement close.
+	
+	statement := client prepare: 'SELECT bytes from table1 WHERE id = $1'.
+	result := statement queryAll: #( ( 123 ) ( 345 ) ).
+	statement close.
+
+	self assert: #( #[ 100 102 104 106 108 ] ) equals: (result at: 1) firstRecord.
+	self assert: #( #[ 100 102 104 106 108 100 102 104 106 108 ] ) equals: (result at: 2) firstRecord.
+	
+]
+
+{ #category : #tests }
 P3PreparedStatementTest >> testBulkInsertAndSelect [
 
 	| insertStatement result selectStatement |

--- a/P3-Tests/P3PreparedStatementTest.class.st
+++ b/P3-Tests/P3PreparedStatementTest.class.st
@@ -63,7 +63,7 @@ P3PreparedStatementTest >> testBinaryColumn [
 	client execute: 'CREATE TABLE table1 (id INTEGER, bytes BYTEA)'.
 	
 	statement := client prepare: 'INSERT INTO table1 (id, bytes) VALUES ($1,$2)'.
-	statement execute: #( 123 #[ 100 102 104 106 108 ] ).
+	statement execute: #( 123 #[ 100 102 104 200 255 0 1 2 ] ).
 	statement execute: #( 345 #[ 100 102 104 106 108 100 102 104 106 108 ]  ).
 	statement close.
 	
@@ -71,7 +71,7 @@ P3PreparedStatementTest >> testBinaryColumn [
 	result := statement queryAll: #( ( 123 ) ( 345 ) ).
 	statement close.
 
-	self assert: #( #[ 100 102 104 106 108 ] ) equals: (result at: 1) firstRecord.
+	self assert: #( #[ 100 102 104 200 255 0 1 2 ] ) equals: (result at: 1) firstRecord.
 	self assert: #( #[ 100 102 104 106 108 100 102 104 106 108 ] ) equals: (result at: 2) firstRecord.
 	
 ]

--- a/P3-Tests/P3PreparedStatementTest.class.st
+++ b/P3-Tests/P3PreparedStatementTest.class.st
@@ -105,6 +105,27 @@ P3PreparedStatementTest >> testBulkInsertAndSelect [
 ]
 
 { #category : #tests }
+P3PreparedStatementTest >> testInsertNull [
+
+	| statement result |
+	
+	client execute: 'DROP TABLE IF EXISTS table1'.
+	client execute: 'CREATE TABLE table1 (id INTEGER, name TEXT)'.
+	
+	statement := client prepare: 'INSERT INTO table1 (id, name) VALUES ($1,$2)'.
+	result := statement executeBatch: #(
+		( 123 'Hello World' )
+		( 345 nil )
+	).
+	
+	self assert: result size equals: 2.
+	result do: [ :each |
+		self assert: each equals: 'INSERT 0 1' ].
+	
+	statement close.
+]
+
+{ #category : #tests }
 P3PreparedStatementTest >> testMultipleInsertStatements [
 
 	| statement1 statement2 |

--- a/P3/ByteArray.extension.st
+++ b/P3/ByteArray.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #ByteArray }
+
+{ #category : #'*P3' }
+ByteArray >> printAsP3TextOn: aStream [
+	"Append to the argument aStream a representation of the receiver in 
+	Postgres text format"
+
+	| v map |
+
+	aStream
+		nextPut: $\;
+		nextPut: $x.
+	map := '0123456789abcdef'.
+	1 to: self size do: [ :i |
+		v := self at: i.
+		aStream 
+			nextPut: (map at: (v bitShift: -4) + 1);
+			nextPut: (map at: (v bitAnd: 15) + 1) ]
+]

--- a/P3/Object.extension.st
+++ b/P3/Object.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #Object }
+
+{ #category : #'*P3' }
+Object >> printAsP3TextOn: aStream [
+	"Append to the argument aStream a representation of the receiver in 
+	Postgres text format"
+
+	self printOn: aStream
+]

--- a/P3/P3Client.class.st
+++ b/P3/P3Client.class.st
@@ -755,7 +755,8 @@ P3Client >> writeMessage: payload [
 	| size |
 	size := payload size + 4.
 	4 to: 1 by: -1 do: [ :index | connection nextPut: (size digitAt: index) ].
-	connection nextPutAll: payload.
+	payload notEmpty 
+		ifTrue: [ connection nextPutAll: payload ].
 	connection flush
 ]
 

--- a/P3/P3Converter.class.st
+++ b/P3/P3Converter.class.st
@@ -12,12 +12,24 @@ Class {
 		'encoder',
 		'timezone',
 		'map',
+		'parameterMap',
 		'stringWriteStream',
 		'asciiReadStream',
 		'asciiWriteStream'
 	],
-	#category : 'P3'
+	#category : #P3
 }
+
+{ #category : #accessing }
+P3Converter class >> parameterConverterMap [
+	"Answer a map with methods that convert a parameter value to its correct
+	text representation. For types without a specific converter method the
+	asString method will be used."
+
+	^ IdentityDictionary newFromPairs: #(
+			17 #convertByteArrayParameter:description:
+		)
+]
 
 { #category : #accessing }
 P3Converter class >> supportedTypes [
@@ -125,6 +137,17 @@ P3Converter >> convertByteArrayFrom: bytes length: length description: descripti
 	^ byteArray 
 ]
 
+{ #category : #'converting-parameters' }
+P3Converter >> convertByteArrayParameter: aByteArray description: paramDescription [
+	"Binary data is encoded as text using hexadecimal digits, e.g. \x1a43fe"
+
+	^ String streamContents: [ :s |
+		s 
+			nextPut: $\; 
+			nextPut: $x;
+			nextPutAll: aByteArray hex ]
+]
+
 { #category : #converting }
 P3Converter >> convertDateAndTimeFrom: bytes length: length description: description [
 	"TIMESTAMP WITH TIME ZONE (TIMESTAMPTZ) is stored internally in Postgres as UTC, but represented in the timezone of the connection, with a correct offset added. In other words, Postgres does the necessary shifting, we just have to read the result"
@@ -188,6 +211,22 @@ P3Converter >> convertJsonFrom: bytes length: length description: description [
 			mapClass: NeoJSONObject;
 			propertyNamesAsSymbols: true;
 			next
+]
+
+{ #category : #'converting-parameters' }
+P3Converter >> convertParameter: aValue description: paramDescription [
+	"Convert the paramemer value to its text representation. This converter can
+	have a type specific converter in its parameterMap. If no specific converter
+	is present use asString."
+
+	| lambda |
+	
+	lambda := parameterMap at: paramDescription typeOid
+		ifAbsent: [ ^ aValue asString ].
+
+	^ lambda isSymbol 
+		ifTrue: [ self perform: lambda with: aValue with: paramDescription ]
+		ifFalse: [ lambda value: aValue value: paramDescription ]
 ]
 
 { #category : #converting }
@@ -273,7 +312,8 @@ P3Converter >> initializeFrom: properties [
 
 { #category : #initalize }
 P3Converter >> initializeTypeMap [
-	map := self class typeMap
+	map := self class typeMap.
+	parameterMap := self class parameterConverterMap
 ]
 
 { #category : #accessing }

--- a/P3/P3Converter.class.st
+++ b/P3/P3Converter.class.st
@@ -12,24 +12,12 @@ Class {
 		'encoder',
 		'timezone',
 		'map',
-		'parameterMap',
 		'stringWriteStream',
 		'asciiReadStream',
 		'asciiWriteStream'
 	],
-	#category : #P3
+	#category : 'P3'
 }
-
-{ #category : #accessing }
-P3Converter class >> parameterConverterMap [
-	"Answer a map with methods that convert a parameter value to its correct
-	text representation. For types without a specific converter method the
-	asString method will be used."
-
-	^ IdentityDictionary newFromPairs: #(
-			17 #convertByteArrayParameter:description:
-		)
-]
 
 { #category : #accessing }
 P3Converter class >> supportedTypes [
@@ -137,17 +125,6 @@ P3Converter >> convertByteArrayFrom: bytes length: length description: descripti
 	^ byteArray 
 ]
 
-{ #category : #'converting-parameters' }
-P3Converter >> convertByteArrayParameter: aByteArray description: paramDescription [
-	"Binary data is encoded as text using hexadecimal digits, e.g. \x1a43fe"
-
-	^ String streamContents: [ :s |
-		s 
-			nextPut: $\; 
-			nextPut: $x;
-			nextPutAll: aByteArray hex ]
-]
-
 { #category : #converting }
 P3Converter >> convertDateAndTimeFrom: bytes length: length description: description [
 	"TIMESTAMP WITH TIME ZONE (TIMESTAMPTZ) is stored internally in Postgres as UTC, but represented in the timezone of the connection, with a correct offset added. In other words, Postgres does the necessary shifting, we just have to read the result"
@@ -211,22 +188,6 @@ P3Converter >> convertJsonFrom: bytes length: length description: description [
 			mapClass: NeoJSONObject;
 			propertyNamesAsSymbols: true;
 			next
-]
-
-{ #category : #'converting-parameters' }
-P3Converter >> convertParameter: aValue description: paramDescription [
-	"Convert the paramemer value to its text representation. This converter can
-	have a type specific converter in its parameterMap. If no specific converter
-	is present use asString."
-
-	| lambda |
-	
-	lambda := parameterMap at: paramDescription typeOid
-		ifAbsent: [ ^ aValue asString ].
-
-	^ lambda isSymbol 
-		ifTrue: [ self perform: lambda with: aValue with: paramDescription ]
-		ifFalse: [ lambda value: aValue value: paramDescription ]
 ]
 
 { #category : #converting }
@@ -312,8 +273,7 @@ P3Converter >> initializeFrom: properties [
 
 { #category : #initalize }
 P3Converter >> initializeTypeMap [
-	map := self class typeMap.
-	parameterMap := self class parameterConverterMap
+	map := self class typeMap
 ]
 
 { #category : #accessing }

--- a/P3/P3MessageBuilder.class.st
+++ b/P3/P3MessageBuilder.class.st
@@ -56,20 +56,26 @@ P3MessageBuilder >> nextPutNullParameter [
 ]
 
 { #category : #writing }
+P3MessageBuilder >> nextPutParameterAsText: aValue description: paramDescription [
+
+	| sizePosition endPosition |
+	
+	sizePosition := byteStream position.
+	byteStream nextPutAll: #[ 0 0 0 0 ]. "placeholder"
+	aValue printAsP3TextOn: (ZnCharacterWriteStream on: byteStream encoding: encoder).
+	endPosition := byteStream position.
+
+	"Go back and set the correct size"
+	byteStream position: sizePosition.
+	byteStream uint32: (endPosition - sizePosition - 4).
+	byteStream position: endPosition
+]
+
+{ #category : #writing }
 P3MessageBuilder >> nextPutString: aString [
 
 	aString do: [ :each | encoder nextPut: each toStream: byteStream ].
 	byteStream nextPut: 0
-]
-
-{ #category : #writing }
-P3MessageBuilder >> nextPutStringParameter: aString [
-
-	| bytes |
-	
-	bytes := encoder encodeString: aString.
-	self nextPutInt32: bytes size.
-	byteStream nextPutAll: bytes
 ]
 
 { #category : #writing }

--- a/P3/P3MessageBuilder.class.st
+++ b/P3/P3MessageBuilder.class.st
@@ -49,6 +49,13 @@ P3MessageBuilder >> nextPutInt32: anInteger [
 ]
 
 { #category : #writing }
+P3MessageBuilder >> nextPutNullParameter [
+	"Write a NULL Parameter"
+
+	self nextPutInt32: -1
+]
+
+{ #category : #writing }
 P3MessageBuilder >> nextPutString: aString [
 
 	aString do: [ :each | encoder nextPut: each toStream: byteStream ].
@@ -56,17 +63,13 @@ P3MessageBuilder >> nextPutString: aString [
 ]
 
 { #category : #writing }
-P3MessageBuilder >> nextPutStringParameter: aValueOrNil [
-	"Write a Parameter in the text format."
+P3MessageBuilder >> nextPutStringParameter: aString [
 
-	aValueOrNil isNil
-		ifTrue: [ 
-			self nextPutInt32: -1 ]
-		ifFalse: [ 
-			| bytes |
-			bytes := encoder encodeString: aValueOrNil asString.
-			self nextPutInt32: bytes size.
-			byteStream nextPutAll: bytes ]
+	| bytes |
+	
+	bytes := encoder encodeString: aString.
+	self nextPutInt32: bytes size.
+	byteStream nextPutAll: bytes
 ]
 
 { #category : #writing }

--- a/P3/P3MessageBuilder.class.st
+++ b/P3/P3MessageBuilder.class.st
@@ -52,7 +52,7 @@ P3MessageBuilder >> nextPutInt32: anInteger [
 P3MessageBuilder >> nextPutNullParameter [
 	"Write a NULL Parameter"
 
-	self nextPutInt32: -1
+	byteStream nextPutAll: #[255 255 255 255]
 ]
 
 { #category : #writing }

--- a/P3/P3ParameterDescription.class.st
+++ b/P3/P3ParameterDescription.class.st
@@ -13,6 +13,16 @@ Class {
 	#category : #P3
 }
 
+{ #category : #converting }
+P3ParameterDescription >> convertToString: paramValue using: converter [
+	"Convert the paramValue to a String representation that Postgres understands."
+	
+	typeOid = 17
+		ifTrue: [ ^ 'X''', paramValue hex, '''' ].
+		
+	^ paramValue asString
+]
+
 { #category : #printing }
 P3ParameterDescription >> printOn: stream [
 	super printOn: stream.

--- a/P3/P3PreparedStatement.class.st
+++ b/P3/P3PreparedStatement.class.st
@@ -120,6 +120,11 @@ P3PreparedStatement >> executeBatch: inputRows [
 ]
 
 { #category : #accessing }
+P3PreparedStatement >> fieldCount [
+	^ fieldDescriptions size
+]
+
+{ #category : #accessing }
 P3PreparedStatement >> fieldDescriptions [
 	^ fieldDescriptions
 ]
@@ -136,6 +141,11 @@ P3PreparedStatement >> initializeWith: aClient name: aString parameters: aParamD
 { #category : #accessing }
 P3PreparedStatement >> name [
 	^ name
+]
+
+{ #category : #accessing }
+P3PreparedStatement >> paramCount [
+	^ paramDescriptions size
 ]
 
 { #category : #accessing }

--- a/P3/P3PreparedStatement.class.st
+++ b/P3/P3PreparedStatement.class.st
@@ -47,6 +47,7 @@ P3PreparedStatement class >> newWith: aClient name: aString parameters: paramDes
 P3PreparedStatement >> bindStrings: inputValues [
 
 	| msgBuilder |
+
 	msgBuilder := client newMessageBuilder.
 	msgBuilder
 		nextPutString: '';
@@ -56,11 +57,8 @@ P3PreparedStatement >> bindStrings: inputValues [
 		
 	inputValues with: paramDescriptions do: [ :eachValue :paramDescription |
 		eachValue isNil
-			ifTrue: [ 
-				msgBuilder nextPutNullParameter ]
-			ifFalse: [ 
-				msgBuilder nextPutStringParameter: (
-					self converter convertParameter: eachValue description: paramDescription) ] ].
+			ifTrue: [ msgBuilder nextPutNullParameter ]
+			ifFalse: [ msgBuilder nextPutParameterAsText: eachValue description: paramDescription ] ].
 
 	msgBuilder 
 		nextPutInt16: 0.	"All result columns use the text format"		

--- a/P3/P3PreparedStatement.class.st
+++ b/P3/P3PreparedStatement.class.st
@@ -54,14 +54,18 @@ P3PreparedStatement >> bindStrings: inputValues [
 		nextPutInt16: 0;
 		nextPutInt16: inputValues size.
 		
-	inputValues do: [ :eachValue |
-		msgBuilder nextPutStringParameter: eachValue ].
+	inputValues with: paramDescriptions do: [ :eachValue :paramDescription |
+		eachValue isNil
+			ifTrue: [ 
+				msgBuilder nextPutNullParameter ]
+			ifFalse: [ 
+				msgBuilder nextPutStringParameter: (
+					self converter convertParameter: eachValue description: paramDescription) ] ].
 
 	msgBuilder 
 		nextPutInt16: 0.	"All result columns use the text format"		
 		
-	client writeMessageNoFlush: msgBuilder asBytes tag: $B 
-
+	client writeMessageNoFlush: msgBuilder asBytes tag: $B
 ]
 
 { #category : #public }
@@ -80,6 +84,11 @@ P3PreparedStatement >> close [
 	
 	"This prepared statement can no longer be used."
 	client := nil
+]
+
+{ #category : #accessing }
+P3PreparedStatement >> converter [ 
+	^ client converter
 ]
 
 { #category : #public }

--- a/P3/ScaledDecimal.extension.st
+++ b/P3/ScaledDecimal.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #ScaledDecimal }
+
+{ #category : #'*P3' }
+ScaledDecimal >> printAsP3TextOn: aStream [
+	"Append to the argument aStream a representation of the receiver in 
+	Postgres text format"
+
+	self printOn: aStream showingDecimalPlaces: scale
+]

--- a/P3/String.extension.st
+++ b/P3/String.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #String }
+
+{ #category : #'*P3' }
+String >> printAsP3TextOn: aStream [
+	"Append to the argument aStream a representation of the receiver in 
+	Postgres text format"
+
+	aStream nextPutAll: self
+]


### PR DESCRIPTION
Hi,
When encoding the input parameters of a prepared statement to the Postgres text format, use a P3 specific "printing" method #printAsP3TextOn: aCharacterStream.
This solution is not yet reusable for the non-prepared statements because of the missing quote handling.