### PR TITLE
Default to string for unknown types.

### DIFF
--- a/P3/P3Converter.class.st
+++ b/P3/P3Converter.class.st
@@ -81,17 +81,13 @@ P3Converter >> asciiStreamFor: bytes length: length [
 
 { #category : #converting }
 P3Converter >> convert: bytes length: length description: description [
-
-	| type lambda |
-	
-	type := map at: description typeOid 
-		ifAbsent: [ self error: 'P3 cannot convert typeOid ', description typeOid asString ].
-		
-	lambda := type second.
-	
-	^ lambda isSymbol 
-		ifTrue: [ self perform: type second with: bytes with: length with: description ]
-		ifFalse: [ lambda value: bytes value: length value: description ]
+	^ map at: description typeOid
+		ifPresent: [ :tuple | tuple second isSymbol
+			ifTrue: [ self perform: tuple second with: bytes with: length with: description ]
+			ifFalse: [ tuple second value: bytes value: length value: description ] ]
+		ifAbsent: [ description format = 0
+			ifTrue: [ self convertStringFrom: bytes length: length description: description ]
+			ifFalse: [ self error: 'P3 cannot convert typeOid ', description typeOid asString ] ]
 ]
 
 { #category : #converting }


### PR DESCRIPTION
Instead of raising an exception for unknown types, convert them to strings if the format was text; binary format will still have the error. I'm mostly interested in this because of enumeration columns, which are just fine as strings. Alternatively could the bit from `testEnum` be automatically convert them to symbols? I couldn't find the right flag for it so far.