### PR TITLE
Fix: multiple command in query

### DIFF
--- a/P3-Tests/P3ClientTest.class.st
+++ b/P3-Tests/P3ClientTest.class.st
@@ -388,6 +388,28 @@ P3ClientTest >> testMultiStatement [
 ]
 
 { #category : #tests }
+P3ClientTest >> testMultipleCommandeInOneRequest [
+	| result |
+	client execute: 'DROP TABLE IF EXISTS table1'.
+	result := client
+		query:
+			'CREATE TABLE table1 (id INTEGER, name TEXT, enabled BOOLEAN);
+INSERT INTO table1 (id, name, enabled) VALUES (1, ''foo'', true);
+INSERT INTO table1 (id, name, enabled) VALUES (2, ''bar'', false);
+INSERT INTO table1 (id, name, enabled) VALUES (NULL, NULL, NULL);
+SELECT id, name, enabled FROM table1 WHERE id = 1;
+SELECT id, name, enabled FROM table1 WHERE id = 2'.
+	self assert: result firstRecord equals: #(2 'bar' false).
+	result := client
+		query:
+			'DELETE FROM table1 WHERE id IS NULL;
+UPDATE table1 SET name = ''xxx'' WHERE id = 2;
+SELECT id, name, enabled FROM table1 WHERE id = 2'.
+	self assert: result firstRecord equals: #(2 'xxx' false).
+	client execute: 'DROP TABLE table1'
+]
+
+{ #category : #tests }
 P3ClientTest >> testNonAsciiStrings [
 	| result |
 	client execute: 'DROP TABLE IF EXISTS table1'.

--- a/P3/P3Client.class.st
+++ b/P3/P3Client.class.st
@@ -902,18 +902,24 @@ P3Client >> runExtendedQueryResults: fieldDescriptions [
 
 { #category : #protocol }
 P3Client >> runQueryResult [
-	| result |
+	| result tag |
 	result := P3Result new.
-	self readMessage tag = $T
-		ifTrue: [ result descriptions: (self processRowDescription: message readStream) ].
-	message tag = $C ifFalse: [ 
-		result data: (Array streamContents: [ :out |
-			[ self readMessage tag = $C ] whileFalse: [ 
-				self assert: message tag = $D.
-				out nextPut: (self processDataRowUsing: result descriptions) ] ]) ].
-	[
-		result addResult: (self converter asciiCStringFrom: message readStream).
-		self readMessage tag = $Z ] whileFalse.
+	self readMessage tag. 
+	[ 
+		message tag  = $T
+		ifTrue: [ result
+				descriptions: (self processRowDescription: message readStream) ].
+	message tag = $C
+		ifFalse: [ result
+				data:
+					(Array
+						streamContents: [ :out | 
+							[ self readMessage tag = $C ]
+								whileFalse: [ self assert: message tag = $D.
+									out nextPut: (self processDataRowUsing: result descriptions) ] ]) ].
+	result
+		addResult: (self converter asciiCStringFrom: message readStream).
+	self readMessage tag = $Z ] whileFalse.
 	self logResult: result.
 	^ result
 ]

--- a/P3/P3Client.class.st
+++ b/P3/P3Client.class.st
@@ -902,7 +902,7 @@ P3Client >> runExtendedQueryResults: fieldDescriptions [
 
 { #category : #protocol }
 P3Client >> runQueryResult [
-	| result tag |
+	| result |
 	result := P3Result new.
 	self readMessage tag. 
 	[ 


### PR DESCRIPTION
Problem :
We use complex schemas and queries. To avoid errors, we define `search_path`. So we have at least 2 orders in a query. P3 gives us empty data in the result in this case (the SET command does not return any data).

example request:
`` ``
SET search_path TO models, "$user", public;
SELECT counts (1) from aTable;
`` ``

Solution:

The P3 customer reads all order returns and only keeps the data of the last order return. 