### PR TITLE
Add oid[] support

### DIFF
--- a/P3/P3Converter.class.st
+++ b/P3/P3Converter.class.st
@@ -63,6 +63,7 @@ P3Converter class >> typeMap [
 			1009 #(#'_text' #convertStringArrayFrom:length:description:)
 			1015 #(#'_varchar' #convertStringArrayFrom:length:description:)
 			1022 #(#'_float8' #convertFloatArrayFrom:length:description:)
+			1028 #(#'_oid' #convertIntegerArrayFrom:length:description:)
 			"geometric"
 			600 #(point #convertPointFrom:length:description:)
 			601 #(lseg #convertLineSegmentFrom:length:description:)


### PR DESCRIPTION
I tried to do `select * from pg_extension` and got an error about oid 1028. Seems that array of oids `oid[]` is not supported.

I fixed that. Here is the table (look for `extconfig` column):

```
               Table "pg_catalog.pg_extension"
┌────────────────┬─────────┬───────────┬──────────┬─────────┐
│     Column     │  Type   │ Collation │ Nullable │ Default │
├────────────────┼─────────┼───────────┼──────────┼─────────┤
│ extname        │ name    │           │ not null │         │
│ extowner       │ oid     │           │ not null │         │
│ extnamespace   │ oid     │           │ not null │         │
│ extrelocatable │ boolean │           │ not null │         │
│ extversion     │ text    │           │ not null │         │
│ extconfig      │ oid[]   │           │          │         │
│ extcondition   │ text[]  │           │          │         │
└────────────────┴─────────┴───────────┴──────────┴─────────┘
```z