### PR TITLE
Support for type oidvector (OID 30)

### DIFF
--- a/P3-Tests/P3ClientTest.class.st
+++ b/P3-Tests/P3ClientTest.class.st
@@ -321,6 +321,34 @@ P3ClientTest >> testIntegerConversion [
 ]
 
 { #category : #tests }
+P3ClientTest >> testIntegerVector [
+
+	| result statement |
+	client execute: 'DROP TABLE IF EXISTS table1'.
+	client execute: 'CREATE TABLE table1 (id INTEGER, v oidvector)'.
+	client execute:
+		'INSERT INTO table1 (id, v) VALUES (1, ''0 1 2 3 4 5 67890 1234567'')'.
+	result := client query: 'SELECT id, v FROM table1 WHERE id = 1'.
+	self
+		assert: result firstRecord
+		equals: #( 1 #( 0 1 2 3 4 5 67890 1234567 ) ).
+
+
+	"statement := client prepare:
+		             'INSERT INTO table1 (id, v) VALUES ($1, $2)'.
+	statement execute: { 
+			1.
+			#( 77 1974 1945 ) }.
+			
+	result := client query: 'SELECT id, v FROM table1 WHERE id = 2'.
+	self assert: result firstRecord equals: { 
+			2.
+			#( 77 1974 1945 ) }."
+
+	client execute: 'DROP TABLE table1'
+]
+
+{ #category : #tests }
 P3ClientTest >> testIntervalConversion [
 	| result |
 	result := client query: 'SELECT INTERVAL ''1 years 1 mons 1 days 1 hours 1 minutes 1 seconds'''.

--- a/P3-Tests/P3IntegerVectorValueParserTest.class.st
+++ b/P3-Tests/P3IntegerVectorValueParserTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #P3IntegerVectorValueParserTest,
+	#superclass : #TestCase,
+	#category : #'P3-Tests'
+}
+
+{ #category : #tests }
+P3IntegerVectorValueParserTest >> testPlain [
+
+	"assuming PostgreSQL will always use exactly one space as separator, but we parse multispace as well"
+
+	self
+		assert: (P3IntegerVectorValueParser new
+				 on: '  12   1221 0 -123 1221   12  ' readStream;
+				 next)
+		equals: #( 12 1221 0 -123 1221 12 )
+]

--- a/P3/P3Converter.class.st
+++ b/P3/P3Converter.class.st
@@ -72,6 +72,8 @@ P3Converter class >> typeMap [
 			604 #(polygon #convertPolygonFrom:length:description:)
 			628 #(line #convertLineFrom:length:description:)
 			718 #(circle #convertCircleFrom:length:description:)
+			"vectors"
+			30 #( oidvector #convertIntegerVectorFrom:length:description: )
 		)
 ]
 
@@ -219,6 +221,16 @@ P3Converter >> convertIntegerArrayFrom: bytes length: length description: descri
 { #category : #converting }
 P3Converter >> convertIntegerFrom: bytes length: length description: description [
 	^ Integer readFrom: (self asciiStreamFor: bytes length: length) base: 10
+]
+
+{ #category : #'converting-arrays' }
+P3Converter >> convertIntegerVectorFrom: bytes length: length description: description [
+	| input |
+	input := ZnLimitedReadStream on: bytes limit: length.
+	input := ZnCharacterReadStream on: input encoding: self encoder.
+	^ P3IntegerVectorValueParser new
+		  on: input;
+		  next
 ]
 
 { #category : #'converting-chronology' }

--- a/P3/P3IntegerVectorValueParser.class.st
+++ b/P3/P3IntegerVectorValueParser.class.st
@@ -1,0 +1,89 @@
+"
+I represent a Parser which can parse ancient PostgreSQL oidvector (OID:30) type, which looks like array of positive integers, but has different textual representation. Example of the textual representation: '2281 26 2281 21 2281'.
+
+We have four different vector types:
+
+```sql
+select distinct typname from pg_type where typname ~ '^[^_].*vector';
+```
+
+```
+┌─────────────┐
+│   typname   │
+├─────────────┤
+│ gtsvector   │
+│ int2vector  │
+│ oidvector   │
+│ tsvector    │
+└─────────────┘
+```
+"
+Class {
+	#name : #P3IntegerVectorValueParser,
+	#superclass : #Object,
+	#instVars : [
+		'stream',
+		'converter'
+	],
+	#category : #'P3-Support'
+}
+
+{ #category : #'private-parsing' }
+P3IntegerVectorValueParser >> consumeWhitespace [
+
+	"Strip whitespaces from the input stream."
+
+	[ stream atEnd not and: [ stream peek = Character space ] ] 
+		whileTrue: [ stream next ]
+]
+
+{ #category : #'private-parsing' }
+P3IntegerVectorValueParser >> convertElement: string [
+	^ converter 
+		ifNil: [ string ]
+		ifNotNil: [ converter value: string ]
+]
+
+{ #category : #'instance creation' }
+P3IntegerVectorValueParser >> converter: block [
+	"Set my converter to block, which will parse the text of array elements"
+	
+	converter := block
+]
+
+{ #category : #initialization }
+P3IntegerVectorValueParser >> initialize [
+
+	"set default converter"
+
+	super initialize.
+	converter := [ :string |  string asInteger]
+]
+
+{ #category : #accessing }
+P3IntegerVectorValueParser >> next [
+
+	"Parse and return the next array value"
+
+	self consumeWhitespace.
+	^ Array streamContents: [ :array | 
+		  [ stream atEnd ] 
+			  whileFalse: [ 
+				  array nextPut: (self convertElement: self parseElement).
+				  self consumeWhitespace.] ]
+]
+
+{ #category : #'instance creation' }
+P3IntegerVectorValueParser >> on: readStream [
+	"Initialize me on the textual readStream given"
+	
+	stream := readStream
+]
+
+{ #category : #'private-parsing' }
+P3IntegerVectorValueParser >> parseElement [
+
+	^ String streamContents: [ :string | 
+		  [ stream atEnd or: [ Character space = stream peek ] ] 
+			  whileFalse: [ string nextPut: stream next ] ]
+]


### PR DESCRIPTION
This time I added tests. More types to come soon!

I've commented code in test:

```smalltalk
statement := client prepare:
		             'INSERT INTO table1 (id, v) VALUES ($1, $2)'.
	statement execute: { 
			1.
			#( 77 1974 1945 ) }.
			
	result := client query: 'SELECT id, v FROM table1 WHERE id = 2'.
	self assert: result firstRecord equals: { 
			2.
			#( 77 1974 1945 ) }.
```

Seems it is not supported to use Smalltalk arrays with `$` placeholders currently even for `INT[]` or `TEXT[]` data types. I could try to add support for it. The idea is that Smalltalk int array could be stored in PostgreSQL in different ways:

- TEXT (VARCHAR) example: `#(1 2 3)`
- INT[]
- JSON example: `[1,2,3]`
- JSONB
- oidvector

and probably others

So Array Object should know PostgreSQL type to correctly format itself. This probably will require some rework in P3