### PR TITLE
Fixed `P3Client>>logResult:` failure when the properties dictionary does not contain the key `#query_started`.

### DIFF
--- a/P3/P3Client.class.st
+++ b/P3/P3Client.class.st
@@ -528,7 +528,7 @@ P3Client >> logResult: result [
 		result: result;
 		duration: duration;
 		emit.
-	properties removeKey: #query_started
+	properties removeKey: #query_started ifAbsent: [  ]
 ]
 
 { #category : #'private - logging' }


### PR DESCRIPTION
The message checks if `properties` contains `#query_started` to calculate the timing information, but does when the key is not present, it fails to remove it from the dictionary.

This PR adds `ifAbsent: [ ]` when trying to remove `#query_started` from the `properties` dictionary.