### PR TITLE
Fix printOn: message.

### DIFF
--- a/P3-Tests/P3FormattedStatementTest.class.st
+++ b/P3-Tests/P3FormattedStatementTest.class.st
@@ -212,6 +212,24 @@ P3FormattedStatementTest >> testNull [
 ]
 
 { #category : #tests }
+P3FormattedStatementTest >> testPrintOn [
+"client format: returns a P3FormattedStatement. Use result to test printOn:"
+
+	| sql p3fs result|
+	
+	sql := 'INSERT INTO table1 (id, name) VALUES ($1, $2)'.
+	
+	p3fs := client format: sql.
+	
+	result := String streamContents: [ :stream | p3fs printOn: stream ].
+	
+	self assert: result contents equals: ('a P3FormattedStatement({1})' format: { sql })
+	
+	
+	
+]
+
+{ #category : #tests }
 P3FormattedStatementTest >> testSimple [
 	| statement result |
 	

--- a/P3/P3FormattedStatement.class.st
+++ b/P3/P3FormattedStatement.class.st
@@ -139,7 +139,7 @@ P3FormattedStatement >> printObject: object on: stream [
 { #category : #printing }
 P3FormattedStatement >> printOn: stream [
 	super printOn: stream.
-	stream nextPut: $(; << sql; nextPut: $)
+	stream nextPut: $(; << source; nextPut: $)
 ]
 
 { #category : #'printing-dispatched' }


### PR DESCRIPTION
Guessing `sql` in the original message refers to source, because that's what the sql: setter message uses.