### PR TITLE
Fix Printing of session ID on close event.

### DIFF
--- a/P3/P3Client.class.st
+++ b/P3/P3Client.class.st
@@ -144,13 +144,15 @@ P3Client >> clearTextPasswordMessage [
 P3Client >> close [
 	"Cleanly close my connection with the server"
 
-	connection ifNotNil: [ 
+	connection ifNotNil: [
+		self logDisconnected. 
 		[ 
 			self writeMessage: #[] tag: $X.
 			connection close ] on: Error do: [  ].
+		
 		self clearSession.
-		connection := nil.
-		self logDisconnected ]
+		connection := nil
+		 ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
In the current implementation of `P3Client>>close`, the closing of the driver nullifies the session id variable and when the log tries to print it, it does not have the value. The result is that the log prints the connect and disconnect events as:

```
2025-11-29 11:01:11 257 [P3] 91307 #Connect psql...
2025-11-29 11:01:11 260 [P3]  #Close
```

moving the log printing event before calling close, allows to see the connection ID in the close event, which helps keep track of the lifetime of the connection.

```
2025-11-29 11:01:11 257 [P3] 91307 #Connect psql...
2025-11-29 11:01:11 260 [P3] 91307 #Close
```

In the current implementation, the `connection close` is sent inside a protected block with an empty error handler, so I think it does not matter if the log event is sent before or after. If the error handler was different, then the solution would be to create the log signal before the close command and then emit the signal after it occurred. If this is preferred, let me know and I can update the code for the PR.


